### PR TITLE
Rft: default config init and Dubbo::init

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -14,3 +14,4 @@ serde = {version="1.0.138", features = ["derive"]}
 serde_yaml = "0.9.4"
 tracing = "0.1"
 lazy_static = "1.3.0"
+once_cell = "1.16.0"

--- a/config/src/protocol.rs
+++ b/config/src/protocol.rs
@@ -46,7 +46,7 @@ impl ProtocolConfig {
         Self { params, ..self }
     }
 
-    pub fn to_url(self) -> String {
+    pub fn to_url(&self) -> String {
         format!("{}://{}:{}", self.name, self.ip, self.port)
     }
 }

--- a/dubbo/src/framework.rs
+++ b/dubbo/src/framework.rs
@@ -53,7 +53,7 @@ impl Dubbo {
     }
 
     pub fn init(&mut self) {
-        let conf = self.config.get_or_insert(get_global_config());
+        let conf = self.config.get_or_insert_with(|| get_global_config());
         tracing::debug!("global conf: {:?}", conf);
 
         for (name, url) in conf.registries.iter() {


### PR DESCRIPTION
fix some problems about config initialized and make the `Dubbo::init` code style "more rust".
close: #65 