### PR TITLE
[ISSUE #161] #[serde(default)] can only be used on structs, not enum

### DIFF
--- a/dubbo-build/src/prost.rs
+++ b/dubbo-build/src/prost.rs
@@ -94,7 +94,7 @@ impl Builder {
         };
         config.out_dir(out_dir);
         config.type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
-        config.type_attribute(".", "#[serde(default)]");
+        config.message_attribute(".", "#[serde(default)]");
 
         if self.compile_well_known_types {
             config.compile_well_known_types();


### PR DESCRIPTION
Fix: `#[serde(default)]` can only be used on structs #161 